### PR TITLE
fix: typo in R install.packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apt install libpq-dev -y
 # Install R packages, if you want to install also
 # the dependencies for Postgres install also
 # RPostgres
-RUN R -e "install.packages(c('shiny', shinyalert'))" 
+RUN R -e "install.packages(c('shiny', 'shinyalert'))" 
 
 # Set new workdir
 WORKDIR /home/app


### PR DESCRIPTION
Fixed a typo in the Dockerfile `RUN` instruction for installing R shiny packages